### PR TITLE
Update gamma-pendulum.ipynb

### DIFF
--- a/scripts/gamma-pendulum.ipynb
+++ b/scripts/gamma-pendulum.ipynb
@@ -44,8 +44,8 @@
       "source": [
         "#@title Clone repo and install dependencies\n",
         "%cd /content\n",
-        "!git clone https://github.com/jannerm/gamma.git\n",
-        "%cd gamma\n",
+        "!git clone https://github.com/jannerm/gamma-models.git\n",
+        "%cd gamma-models\n",
         "%pip install git+https://github.com/jannerm/rlkit.git@5d355ba04145c75f59fcd53823784b5e3329f365\n",
         "%pip install sk-video==1.1.10\n",
         "%pip install -e ."


### PR DESCRIPTION
fix repo name in jupyter notebook

github.com/jannerm/gamma --> /gamma-models

The colab example doesn't run without this change.